### PR TITLE
Forbid incompatible IntervalArithmetic v0.21

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 
 [compat]
-IntervalArithmetic = "0.20"
+IntervalArithmetic = "0.20, < 0.21"
 MultivariatePolynomials = "0.4 - 0.5"
 RecursiveArrayTools = "2"
 Reexport = "1.2"


### PR DESCRIPTION
This is mainly to prevent attempts from `CompatHelper`.

Since there are explicit tests for `Rational`s, I presumed that they should be supported. But they were dropped in `IntervalArithmetic` v0.21. For the record, this is the first error in the tests:

```julia
Univariate monomial, rational: Error During Test at BernsteinExpansions/test/runtests.jl:24
  Test threw exception
  Expression: univariate(x ^ 3, 3, Interval(1 // 1, 2 // 1)) == [1 // 1, 2 // 1, 4 // 1, 8 // 1]
  MethodError: no method matching Interval(::Rational{Int64}, ::Rational{Int64})
```